### PR TITLE
Add left shoe underbar and right shoe underbar

### DIFF
--- a/dyalog-mode.el
+++ b/dyalog-mode.el
@@ -95,7 +95,7 @@ together with AltGr produce the corresponding apl character in APLCHARS."
   "APL symbols also present in ASCII.")
 
 (defvar dyalog-keyword-chars
-  "×≤≥≠∨∧÷∊⍴↑↓⍳○←→⌈⌊∘⍎⍕⊂⊃∩∪⊥⊤⍨⍒⍋⌽⍉⊖⍟⍱⍲⍬⌹≡≢⍪⌿⍀⍺⍵⎕⍞⋄⍷⍸⌷⍣⊣⊢⌶")
+  "×≤≥≠∨∧÷∊⍴↑↓⍳○←→⌈⌊∘⍎⍕⊂⊃⊆⊇∩∪⊥⊤⍨⍒⍋⌽⍉⊖⍟⍱⍲⍬⌹≡≢⍪⌿⍀⍺⍵⎕⍞⋄⍷⍸⌷⍣⊣⊢⌶")
 
 (defvar dyalog-name  "[A-Za-z∆_]+[A-Za-z∆_0-9]*")
 


### PR DESCRIPTION
Left shoe underbar will be used in Dyalog 16.0. Right shoe underbar might be used in the future.